### PR TITLE
Fix Jupyterlab versioning

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - jupyter-packaging
   run:
     - python >=3.6
-    - jupyterlab >=3.0.0rc13,==3.*
+    - jupyterlab >=3,<4
 
 test:
   requires:


### PR DESCRIPTION
On install, `mamba` gives the error
```
Problem: nothing provides jupyterlab >=3.0.0rc13,==3.* needed by jupyterlab_execute_time-2.0.1-pyhd8ed1ab_0
```
although JupyterLab is at 3.0.5. Conda gives the following clue:
```
Collecting package metadata (current_repodata.json): / WARNING conda.models.version:get_matcher(537): Using .* with relational operator is superfluous and deprecated and will be removed in a future version of conda. Your spec was 3.*, but conda is ignoring the .* and treating it as 3
```
My suspicion is that the version string is malformed, hence my proposed change.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
